### PR TITLE
Use .empty().append() instead of .html()

### DIFF
--- a/javascript/base.js
+++ b/javascript/base.js
@@ -126,7 +126,7 @@
 
 		var replaceRegion = function(html, key) {
 			var $foundRegion = false,
-				$region = $(html)[0],
+				$region = $(html),
 				explicit = $('[data-ajax-region="' + key + '"]'),
 				explicit2 = $('[data-ajax-region^="' + key + ':"]'),
 				id = $region.length > 0 ? $region.prop('id') : '',
@@ -150,7 +150,7 @@
 			}
 			
 			if ($foundRegion && $foundRegion.length){
-				$foundRegion.empty().append($region);
+				$foundRegion.empty().append($region.html());
 			} else {
 				// finally we fail silently but leave a warning for the developer
 				if (typeof(console) != 'undefined' && typeof(console.warn) == 'function') {


### PR DESCRIPTION
Using .html() to update the contents caused issues with child elements that had events attached to them.
Also, I had a few issues with $region.html(), first request worked fine, but subsequent requests $region.html() would only return a portion of the html received.
This is probably because I'm attaching tinymce to elements received from ajax.

Using .empty() removes all event handlers and data on child elements before removing them.
Using .append(), $region does not have to be converted to text again.

While this has fixed my issue, and functions alright. I do not know if it may cause side affects.
