### PR TITLE
Fix issue in base.js

### DIFF
--- a/javascript/base.js
+++ b/javascript/base.js
@@ -152,7 +152,7 @@
 			}
 			
 			if ($foundRegion && $foundRegion.length){
-				$foundRegion.empty().append($region.html());
+				$foundRegion.empty().append($region);
 			} else {
 				// finally we fail silently but leave a warning for the developer
 				if (typeof(console) != 'undefined' && typeof(console.warn) == 'function') {


### PR DESCRIPTION
The incoming html is already wrapped as jQuery element on line 131. Additionally calling `.html()` removes the outermost dom-node from the response, which is an undesired effect.